### PR TITLE
feat: handle empty weekly data with creative fallback message

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -1,4 +1,4 @@
-import { adjustAndPad } from "./index.js";
+import { adjustAndPad, createTopArtistList, generateChart } from "./index.js";
 import { test, expect, describe } from "bun:test";
 
 describe("testing East Asian name truncation and padding", () => {
@@ -58,5 +58,136 @@ describe("testing edge cases", () => {
   });
   test("zero width should be empty string", () => {
     expect(adjustAndPad("a", 0)).toBe("");
+  });
+});
+
+// Mock configuration for testing
+const mockConfig = {
+  gistId: "test-gist",
+  githubToken: "test-token", 
+  lastfmKey: "test-key",
+  lastfmUsername: "test-user"
+};
+
+describe("Empty Data Handling", () => {
+  test("should return creative message when no artists", async () => {
+    const originalLog = console.log;
+    let logMessage = "";
+    console.log = (message: string) => { logMessage = message; };
+    
+    const result = await createTopArtistList([], 5, mockConfig);
+    
+    expect(result).toBe("No spotify this week – probably exploring podcasts, audiobooks and analog music.");
+    expect(logMessage).toBe("No listening data found for this week - using fallback message");
+    
+    console.log = originalLog;
+  });
+
+  test("should return creative message when total plays is zero", async () => {
+    const originalLog = console.log;
+    let logMessage = "";
+    console.log = (message: string) => { logMessage = message; };
+    
+    // Create properly typed artist objects with zero play counts
+    const artistsWithZeroPlays = [
+      {
+        streamable: 0 as const,
+        image: [{ "#text": "", size: "" }],
+        mbid: "",
+        url: "",
+        playcount: "0",
+        "@attr": { rank: "1" },
+        name: "Artist 1"
+      },
+      {
+        streamable: 0 as const,
+        image: [{ "#text": "", size: "" }],
+        mbid: "",
+        url: "",
+        playcount: "0",
+        "@attr": { rank: "2" },
+        name: "Artist 2"
+      }
+    ];
+    
+    const result = await createTopArtistList(artistsWithZeroPlays, 5, mockConfig);
+    
+    expect(result).toBe("No spotify this week – probably exploring podcasts, audiobooks and analog music.");
+    expect(logMessage).toBe("Total plays is zero - using fallback message");
+    
+    console.log = originalLog;
+  });
+});
+
+describe("Chart Generation Edge Cases", () => {
+  test("should handle NaN input gracefully", () => {
+    const originalLog = console.log;
+    let logMessage = "";
+    console.log = (message: string) => { logMessage = message; };
+    
+    const result = generateChart(NaN, 10);
+    
+    expect(result).toBe("–––––|––––");
+    expect(logMessage).toBe("Invalid fraction value: NaN - using balanced chart");
+    
+    console.log = originalLog;
+  });
+
+  test("should handle Infinity input gracefully", () => {
+    const originalLog = console.log;
+    let logMessage = "";
+    console.log = (message: string) => { logMessage = message; };
+    
+    const result = generateChart(Infinity, 10);
+    
+    expect(result).toBe("–––––|––––");
+    expect(logMessage).toBe("Invalid fraction value: Infinity - using balanced chart");
+    
+    console.log = originalLog;
+  });
+
+  test("should handle negative input gracefully", () => {
+    const originalLog = console.log;
+    let logMessage = "";
+    console.log = (message: string) => { logMessage = message; };
+    
+    const result = generateChart(-0.5, 10);
+    
+    expect(result).toBe("–––––|––––");
+    expect(logMessage).toBe("Invalid fraction value: -0.5 - using balanced chart");
+    
+    console.log = originalLog;
+  });
+
+  test("should handle normal input correctly", () => {
+    const result = generateChart(0.3, 10);
+    expect(result).toBe("–––|––––––");
+  });
+
+  test("should handle 0% fraction correctly", () => {
+    const result = generateChart(0, 10);
+    expect(result).toBe("|–––––––––");
+  });
+
+  test("should handle 100% fraction correctly", () => {
+    const result = generateChart(1, 10);
+    expect(result).toBe("–––––––––|");
+  });
+});
+
+describe("Integration Tests", () => {
+  test("should handle real Last.fm empty response structure", async () => {
+    const originalLog = console.log;
+    let logMessage = "";
+    console.log = (message: string) => { logMessage = message; };
+    
+    const emptyLastFMResponse: never[] = [];
+    
+    const result = await createTopArtistList(emptyLastFMResponse, 5, mockConfig);
+    
+    expect(result).toBe("No spotify this week – probably exploring podcasts, audiobooks and analog music.");
+    expect(logMessage).toBe("No listening data found for this week - using fallback message");
+    
+    console.log = originalLog;
   });
 });

--- a/index.test.ts
+++ b/index.test.ts
@@ -72,21 +72,21 @@ const mockConfig = {
 describe("Empty Data Handling", () => {
   test("should return creative message when no artists", async () => {
     const originalLog = console.log;
-    let logMessage = "";
-    console.log = (message: string) => { logMessage = message; };
+    const logMessages: string[] = [];
+    console.log = (message: string) => { logMessages.push(message); };
     
     const result = await createTopArtistList([], 5, mockConfig);
     
     expect(result).toBe("No spotify this week – probably exploring podcasts, audiobooks and analog music.");
-    expect(logMessage).toBe("No listening data found for this week - using fallback message");
+    expect(logMessages[0]).toBe("No listening data found for this week - using fallback message");
     
     console.log = originalLog;
   });
 
   test("should return creative message when total plays is zero", async () => {
     const originalLog = console.log;
-    let logMessage = "";
-    console.log = (message: string) => { logMessage = message; };
+    const logMessages: string[] = [];
+    console.log = (message: string) => { logMessages.push(message); };
     
     // Create properly typed artist objects with zero play counts
     const artistsWithZeroPlays = [
@@ -113,7 +113,7 @@ describe("Empty Data Handling", () => {
     const result = await createTopArtistList(artistsWithZeroPlays, 5, mockConfig);
     
     expect(result).toBe("No spotify this week – probably exploring podcasts, audiobooks and analog music.");
-    expect(logMessage).toBe("Total plays is zero - using fallback message");
+    expect(logMessages[0]).toBe("Total plays is zero - using fallback message");
     
     console.log = originalLog;
   });
@@ -122,39 +122,39 @@ describe("Empty Data Handling", () => {
 describe("Chart Generation Edge Cases", () => {
   test("should handle NaN input gracefully", () => {
     const originalLog = console.log;
-    let logMessage = "";
-    console.log = (message: string) => { logMessage = message; };
+    const logMessages: string[] = [];
+    console.log = (message: string) => { logMessages.push(message); };
     
     const result = generateChart(NaN, 10);
     
     expect(result).toBe("–––––|––––");
-    expect(logMessage).toBe("Invalid fraction value: NaN - using balanced chart");
+    expect(logMessages[0]).toBe("Invalid fraction value: NaN - using balanced chart");
     
     console.log = originalLog;
   });
 
   test("should handle Infinity input gracefully", () => {
     const originalLog = console.log;
-    let logMessage = "";
-    console.log = (message: string) => { logMessage = message; };
+    const logMessages: string[] = [];
+    console.log = (message: string) => { logMessages.push(message); };
     
     const result = generateChart(Infinity, 10);
     
     expect(result).toBe("–––––|––––");
-    expect(logMessage).toBe("Invalid fraction value: Infinity - using balanced chart");
+    expect(logMessages[0]).toBe("Invalid fraction value: Infinity - using balanced chart");
     
     console.log = originalLog;
   });
 
   test("should handle negative input gracefully", () => {
     const originalLog = console.log;
-    let logMessage = "";
-    console.log = (message: string) => { logMessage = message; };
+    const logMessages: string[] = [];
+    console.log = (message: string) => { logMessages.push(message); };
     
     const result = generateChart(-0.5, 10);
     
     expect(result).toBe("–––––|––––");
-    expect(logMessage).toBe("Invalid fraction value: -0.5 - using balanced chart");
+    expect(logMessages[0]).toBe("Invalid fraction value: -0.5 - using balanced chart");
     
     console.log = originalLog;
   });
@@ -178,15 +178,15 @@ describe("Chart Generation Edge Cases", () => {
 describe("Integration Tests", () => {
   test("should handle real Last.fm empty response structure", async () => {
     const originalLog = console.log;
-    let logMessage = "";
-    console.log = (message: string) => { logMessage = message; };
+    const logMessages: string[] = [];
+    console.log = (message: string) => { logMessages.push(message); };
     
     const emptyLastFMResponse: never[] = [];
     
     const result = await createTopArtistList(emptyLastFMResponse, 5, mockConfig);
     
     expect(result).toBe("No spotify this week – probably exploring podcasts, audiobooks and analog music.");
-    expect(logMessage).toBe("No listening data found for this week - using fallback message");
+    expect(logMessages[0]).toBe("No listening data found for this week - using fallback message");
     
     console.log = originalLog;
   });

--- a/index.ts
+++ b/index.ts
@@ -170,7 +170,7 @@ export function adjustAndPad(str: string, maxWidth: number) {
 
 export function generateChart(fraction: number, size: number) {
   // Handle edge cases (NaN, Infinity, negative numbers)
-  if (!isFinite(fraction) || fraction < 0) {
+  if (!isFinite(fraction) || fraction < 0 || fraction > 1) {
     console.log(`Invalid fraction value: ${fraction} - using balanced chart`);
     // Return a balanced chart as fallback
     const middle = Math.floor(size / 2);

--- a/index.ts
+++ b/index.ts
@@ -97,16 +97,28 @@ async function getTopArtists(config: Config) {
   return artist;
 }
 
-async function createTopArtistList(
+export async function createTopArtistList(
   artists: LastFMUserGetTopArtistsResponse["topartists"]["artist"],
   listLength: number,
   config: Config
 ) {
+  // Handle empty data case with creative message
+  if (artists.length === 0) {
+    console.log("No listening data found for this week - using fallback message");
+    return "No spotify this week – probably exploring podcasts, audiobooks and analog music.";
+  }
+
   const numberOfArtists = Math.min(listLength, artists.length);
 
   const totalPlays = artists
     .slice(0, numberOfArtists)
     .reduce((total, { playcount }) => total + parseInt(playcount, 10), 0);
+
+  // Additional safeguard for edge cases where total plays is zero
+  if (totalPlays === 0) {
+    console.log("Total plays is zero - using fallback message");
+    return "No spotify this week – probably exploring podcasts, audiobooks and analog music.";
+  }
 
   const lines = await Promise.all(
     artists.map(async ({ name, playcount }, index) => {
@@ -156,9 +168,19 @@ export function adjustAndPad(str: string, maxWidth: number) {
   return truncatedStr + " ".repeat(paddingNeeded);
 }
 
-function generateChart(fraction: number, size: number) {
+export function generateChart(fraction: number, size: number) {
+  // Handle edge cases (NaN, Infinity, negative numbers)
+  if (!isFinite(fraction) || fraction < 0) {
+    console.log(`Invalid fraction value: ${fraction} - using balanced chart`);
+    // Return a balanced chart as fallback
+    const middle = Math.floor(size / 2);
+    return "–".repeat(middle) + "|" + "–".repeat(size - middle - 1);
+  }
+  
   const position = Math.floor(fraction * size);
-  return "–".repeat(position) + "|" + "–".repeat(size - position - 1);
+  // Ensure position is within bounds (0 to size-1)
+  const clampedPosition = Math.min(Math.max(position, 0), size - 1);
+  return "–".repeat(clampedPosition) + "|" + "–".repeat(size - clampedPosition - 1);
 }
 
 async function isArtistNewThisWeek(
@@ -218,6 +240,9 @@ async function updateGist(
   }
 }
 
-(async () => {
-  await main();
-})();
+// Only run main when not in test environment
+if (!process.env.NODE_ENV?.includes('test')) {
+  (async () => {
+    await main();
+  })();
+}


### PR DESCRIPTION
- Add fallback message when no Last.fm data exists for week
- Prevent division-by-zero errors in chart generation
- Add comprehensive test suite for edge cases
- Export functions for proper testing
- Add debug logging for troubleshooting

Fixes crash when no music listened to in a week by showing creative message 'No spotify this week – probably exploring podcasts, audiobooks and analog music.'