### PR TITLE
Add parallel analytics gist pipeline, partial-failure workflow, unify chart styling

### DIFF
--- a/.github/workflows/update-chart.yml
+++ b/.github/workflows/update-chart.yml
@@ -15,9 +15,22 @@ jobs:
         
       - run: bun install
       - run: bun run build
-      - run: bun dist/index.js
+      - id: update_artists
+        continue-on-error: true
+        run: bun dist/index.js
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           LASTFM_KEY: ${{ secrets.LASTFM_KEY }}
           LASTFM_USERNAME: ${{ secrets.LASTFM_USERNAME }}
-          GIST_ID: ${{ secrets.GIST_ID }}
+          ARTISTS_GIST_ID: ${{ secrets.ARTISTS_GIST_ID }}
+      - id: update_analytics
+        continue-on-error: true
+        run: bun dist/analytics.js
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          LASTFM_KEY: ${{ secrets.LASTFM_KEY }}
+          LASTFM_USERNAME: ${{ secrets.LASTFM_USERNAME }}
+          ANALYTICS_GIST_ID: ${{ secrets.ANALYTICS_GIST_ID }}
+      - name: Fail if both updates fail
+        if: ${{ steps.update_artists.outcome == 'failure' && steps.update_analytics.outcome == 'failure' }}
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # Weekly Listens
 
-A script to fetch the top played artists from Last.fm and write them to a Gist, like this:
+A script to fetch Last.fm listening data and write two companion gists:
+
+1. Artist leaderboard gist
+2. Weekly listening analytics gist
+
+Artist gist output looks like:
 
 ```text
-Martin Luke Brown            –––|––––––––    23 plays
-Mk.gee                       ––|–––––––––    17 plays
-Genevieve Artadi *           ––|–––––––––    14 plays
-Low Roar                     –|––––––––––    10 plays
-Nilüfer Yanya                –|––––––––––     9 plays
+Martin Luke Brown            ██████░░░░░░    23 plays
+Mk.gee                       ████░░░░░░░░    17 plays
+Genevieve Artadi *           ████░░░░░░░░    14 plays
+Low Roar                     ███░░░░░░░░░    10 plays
+Nilüfer Yanya                ██░░░░░░░░░░     9 plays
 
 * = new this week
 ```
@@ -16,7 +21,7 @@ Nilüfer Yanya                –|––––––––––     9 plays
 
 You will need to:
 
-1. Create a new Gist on GitHub.
+1. Create two Gists on GitHub (artists + analytics).
 2. Create a new Last.fm API key.
 3. Create a new GitHub token with gist and repo scopes.
 
@@ -25,7 +30,8 @@ Then create a `.env` file in the root of the project with the following variable
 ```bash
 # .env
 
-GIST_ID=
+ARTISTS_GIST_ID=
+ANALYTICS_GIST_ID=
 GH_TOKEN=
 LASTFM_KEY=
 LASTFM_USERNAME=

--- a/analytics.test.ts
+++ b/analytics.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import {
+  calculateGini,
+  calculateVelocity,
+  generateProgressBar,
+} from "./analytics.js";
+
+describe("calculateGini", () => {
+  test("returns 0 for empty values", () => {
+    expect(calculateGini([])).toBe(0);
+  });
+
+  test("returns 0 for equal values", () => {
+    expect(calculateGini([10, 10, 10, 10])).toBe(0);
+  });
+
+  test("returns high inequality score for skewed values", () => {
+    const score = calculateGini([100, 0, 0, 0]);
+    expect(score).toBeGreaterThan(0.7);
+  });
+});
+
+describe("calculateVelocity", () => {
+  test("returns null when fewer than four prior weeks are available", () => {
+    expect(calculateVelocity(100, [80, 90, 95])).toBeNull();
+  });
+
+  test("returns null when trailing average is zero", () => {
+    expect(calculateVelocity(0, [0, 0, 0, 0])).toBeNull();
+  });
+
+  test("calculates percentage delta against trailing 4-week average", () => {
+    const velocity = calculateVelocity(120, [100, 100, 100, 100]);
+    expect(velocity).toBe(20);
+  });
+});
+
+describe("generateProgressBar", () => {
+  test("renders clamped bars", () => {
+    expect(generateProgressBar(0)).toBe("░░░░░░░░░░");
+    expect(generateProgressBar(0.5)).toBe("█████░░░░░");
+    expect(generateProgressBar(1)).toBe("██████████");
+  });
+
+  test("renders a balanced bar for invalid values", () => {
+    expect(generateProgressBar(Number.NaN)).toBe("█████░░░░░");
+  });
+});

--- a/analytics.ts
+++ b/analytics.ts
@@ -488,10 +488,13 @@ function createAnalyticsMarkdown(args: {
         );
 
   return [
-    "📊 Weekly Listening Stats",
-    `DEPTH      ${depthValue}  ${depthBar}  ${describeDepth(current.depthScore)}`,
+    `DEPTH      ${depthValue}  ${depthBar}  ${describeDepth(
+      current.depthScore
+    )}`,
     `DISCOVERY  ${discoveryPercent}%   ${discoveryBar}  ${currentDiscovery.newArtists} new artists *`,
-    `VELOCITY   ${velocityLabel}  ${velocityBar}  ${describeVelocity(velocity)}`,
+    `VELOCITY   ${velocityLabel}  ${velocityBar}  ${describeVelocity(
+      velocity
+    )}`,
     "",
     `vs last week: ${depthTrend}  ${discoveryTrend}  ${velocityTrend}`,
     `Top 5 Coverage: ${Math.round(topFiveCoverage)}% of total plays`,
@@ -499,7 +502,6 @@ function createAnalyticsMarkdown(args: {
     `Total Scrobbles: ${current.totalScrobbles}`,
     "",
     "* = new this week",
-    `Updated at: ${new Date().toISOString()}`,
   ].join("\n");
 }
 

--- a/analytics.ts
+++ b/analytics.ts
@@ -1,0 +1,536 @@
+import { Octokit } from "octokit";
+import fetch from "node-fetch";
+import {
+  type LastFMArtistGetInfoResponse,
+  type LastFMUserGetWeeklyArtistChartResponse,
+  type LastFMUserGetWeeklyChartListResponse,
+} from "./types.js";
+import { type GetResponseTypeFromEndpointMethod } from "@octokit/types";
+
+const BAR_SIZE = 10;
+const HISTORY_WEEKS = 4;
+const REQUIRED_WINDOWS = 6;
+const NEW_ARTIST_CHECK_CONCURRENCY = 5;
+
+const config = {
+  gistId: process.env.ANALYTICS_GIST_ID,
+  githubToken: process.env.GH_TOKEN,
+  lastfmKey: process.env.LASTFM_KEY,
+  lastfmUsername: process.env.LASTFM_USERNAME,
+};
+
+type Config = typeof config;
+
+type WeeklyWindow = {
+  from: number;
+  to: number;
+};
+
+type ArtistPlay = {
+  name: string;
+  playcount: number;
+};
+
+type WeeklyMetrics = {
+  artists: ArtistPlay[];
+  totalScrobbles: number;
+  uniqueArtists: number;
+  depthScore: number;
+};
+
+type DiscoveryMetrics = {
+  newArtists: number;
+  discoveryRate: number;
+};
+
+const octokit = new Octokit({
+  auth: `${config.githubToken}`,
+});
+
+async function main() {
+  if (
+    !config.gistId ||
+    !config.githubToken ||
+    !config.lastfmKey ||
+    !config.lastfmUsername
+  ) {
+    throw new Error("Required env vars are missing");
+  }
+
+  try {
+    const runDate = new Date().toISOString().split("T")[0];
+    const gist = await getGist(config.gistId);
+    const windows = await getWeeklyWindows(config, REQUIRED_WINDOWS);
+
+    const weeklyMetrics: WeeklyMetrics[] = [];
+    for (const window of windows) {
+      try {
+        const artists = await getWeeklyArtists(config, window);
+        weeklyMetrics.push(createWeeklyMetrics(artists));
+      } catch (error) {
+        console.warn(
+          `Skipping weekly window ${window.from}-${window.to}: ${
+            error instanceof Error ? error.message : error
+          }`
+        );
+      }
+    }
+
+    const current = weeklyMetrics[0];
+    if (!current) {
+      throw new Error("No weekly metrics could be calculated");
+    }
+
+    const newArtistCache = new Map<string, Promise<number | null>>();
+    const currentDiscovery = await getDiscoveryMetrics(
+      current.artists,
+      config,
+      newArtistCache
+    );
+    const previousDiscovery =
+      weeklyMetrics[1] !== undefined
+        ? await getDiscoveryMetrics(
+            weeklyMetrics[1].artists,
+            config,
+            newArtistCache
+          )
+        : null;
+
+    const velocity = calculateVelocity(
+      current.totalScrobbles,
+      weeklyMetrics.slice(1, 1 + HISTORY_WEEKS).map((week) => week.totalScrobbles)
+    );
+    const previousVelocity =
+      weeklyMetrics.length >= REQUIRED_WINDOWS
+        ? calculateVelocity(
+            weeklyMetrics[1].totalScrobbles,
+            weeklyMetrics
+              .slice(2, 2 + HISTORY_WEEKS)
+              .map((week) => week.totalScrobbles)
+          )
+        : null;
+
+    const previousDepth = weeklyMetrics[1]?.depthScore ?? null;
+    const topFiveCoverage = calculateTopFiveCoverage(current.artists);
+    const content = createAnalyticsMarkdown({
+      runDate,
+      current,
+      currentDiscovery,
+      velocity,
+      previousDepth,
+      previousDiscoveryRate: previousDiscovery?.discoveryRate ?? null,
+      previousVelocity,
+      topFiveCoverage,
+    });
+
+    const title = `📊 Weekly Listening Stats ${runDate}`;
+
+    if (process.env.NODE_ENV === "development") {
+      console.log("Gist would be updated with this content in production:\n");
+      console.log(title);
+      console.log(content);
+    } else {
+      await updateGist(gist, title, content, config);
+    }
+  } catch (error) {
+    console.error("An error occurred:", error);
+    process.exit(1);
+  }
+}
+
+async function getGist(id: string) {
+  try {
+    return await octokit.rest.gists.get({
+      gist_id: id,
+    });
+  } catch (error) {
+    console.error(`Error fetching gist: ${id}:`, error);
+    throw new Error(
+      `Failed to fetch gist: ${error instanceof Error ? error.message : error}`
+    );
+  }
+}
+
+async function getWeeklyWindows(config: Config, count: number): Promise<WeeklyWindow[]> {
+  const { lastfmKey, lastfmUsername } = config;
+  const endpoint =
+    `https://ws.audioscrobbler.com/2.0/?method=user.getweeklychartlist` +
+    `&user=${lastfmUsername}&api_key=${lastfmKey}&format=json`;
+  const response = await fetch(endpoint);
+  if (!response.ok) {
+    throw new Error(`Last.fm API request failed with status ${response.status}`);
+  }
+
+  const data =
+    (await response.json()) as LastFMUserGetWeeklyChartListResponse;
+  const charts = data.weeklychartlist?.chart ?? [];
+  const normalized = charts
+    .map((chart) => ({
+      from: Number.parseInt(chart.from, 10),
+      to: Number.parseInt(chart.to, 10),
+    }))
+    .filter((chart) => Number.isFinite(chart.from) && Number.isFinite(chart.to))
+    .sort((a, b) => b.to - a.to);
+
+  if (normalized.length === 0) {
+    throw new Error("No weekly chart windows returned from Last.fm");
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const completedWindows = normalized.filter((chart) => chart.to <= now);
+  const source = completedWindows.length > 0 ? completedWindows : normalized;
+  return source.slice(0, count);
+}
+
+async function getWeeklyArtists(
+  config: Config,
+  window: WeeklyWindow
+): Promise<ArtistPlay[]> {
+  const { lastfmKey, lastfmUsername } = config;
+  const endpoint =
+    `https://ws.audioscrobbler.com/2.0/?method=user.getweeklyartistchart` +
+    `&user=${lastfmUsername}&from=${window.from}&to=${window.to}` +
+    `&api_key=${lastfmKey}&format=json`;
+  const response = await fetch(endpoint);
+  if (!response.ok) {
+    throw new Error(`Last.fm API request failed with status ${response.status}`);
+  }
+
+  const data =
+    (await response.json()) as LastFMUserGetWeeklyArtistChartResponse;
+  const rawArtists = data.weeklyartistchart?.artist;
+  const artistList = normalizeArtistList(rawArtists);
+  return artistList
+    .map((artist) => ({
+      name: artist.name,
+      playcount: Number.parseInt(artist.playcount, 10),
+    }))
+    .filter((artist) => Number.isFinite(artist.playcount) && artist.playcount > 0);
+}
+
+function normalizeArtistList(
+  artists: LastFMUserGetWeeklyArtistChartResponse["weeklyartistchart"]["artist"] | undefined
+) {
+  if (artists === undefined) {
+    return [];
+  }
+  return Array.isArray(artists) ? artists : [artists];
+}
+
+function createWeeklyMetrics(artists: ArtistPlay[]): WeeklyMetrics {
+  const totalScrobbles = artists.reduce(
+    (total, artist) => total + artist.playcount,
+    0
+  );
+  return {
+    artists,
+    totalScrobbles,
+    uniqueArtists: artists.length,
+    depthScore: calculateGini(artists.map((artist) => artist.playcount)),
+  };
+}
+
+export function calculateGini(values: number[]): number {
+  const nonNegativeValues = values.filter((value) => value >= 0);
+  const count = nonNegativeValues.length;
+  if (count === 0) {
+    return 0;
+  }
+
+  const total = nonNegativeValues.reduce((sum, value) => sum + value, 0);
+  if (total === 0) {
+    return 0;
+  }
+
+  const sorted = [...nonNegativeValues].sort((a, b) => a - b);
+  let weightedSum = 0;
+  for (let index = 0; index < sorted.length; index += 1) {
+    const position = index + 1;
+    weightedSum += (2 * position - count - 1) * sorted[index];
+  }
+
+  return Math.min(Math.max(weightedSum / (count * total), 0), 1);
+}
+
+async function getDiscoveryMetrics(
+  artists: ArtistPlay[],
+  config: Config,
+  cache: Map<string, Promise<number | null>>
+): Promise<DiscoveryMetrics> {
+  if (artists.length === 0) {
+    return {
+      newArtists: 0,
+      discoveryRate: 0,
+    };
+  }
+
+  const flags = await mapWithConcurrency(
+    artists,
+    NEW_ARTIST_CHECK_CONCURRENCY,
+    async (artist) =>
+      isArtistNewThisWeek(artist.name, artist.playcount, config, cache)
+  );
+  const newArtists = flags.filter(Boolean).length;
+  return {
+    newArtists,
+    discoveryRate: (newArtists / artists.length) * 100,
+  };
+}
+
+async function mapWithConcurrency<T, U>(
+  values: T[],
+  concurrency: number,
+  mapper: (value: T) => Promise<U>
+): Promise<U[]> {
+  if (values.length === 0) {
+    return [];
+  }
+
+  const result = new Array<U>(values.length);
+  let nextIndex = 0;
+  const workers = new Array(Math.min(concurrency, values.length))
+    .fill(0)
+    .map(async () => {
+      while (nextIndex < values.length) {
+        const currentIndex = nextIndex;
+        nextIndex += 1;
+        result[currentIndex] = await mapper(values[currentIndex]);
+      }
+    });
+
+  await Promise.all(workers);
+  return result;
+}
+
+async function isArtistNewThisWeek(
+  artistName: string,
+  weeklyPlaycount: number,
+  config: Config,
+  cache: Map<string, Promise<number | null>>
+) {
+  const key = artistName.toLowerCase();
+  const cached = cache.get(key);
+  if (cached !== undefined) {
+    const cachedPlaycount = await cached;
+    return cachedPlaycount !== null && cachedPlaycount === weeklyPlaycount;
+  }
+
+  const fetchPromise = getUserPlaycount(artistName, config);
+  cache.set(key, fetchPromise);
+  const userPlaycount = await fetchPromise;
+  return userPlaycount !== null && userPlaycount === weeklyPlaycount;
+}
+
+async function getUserPlaycount(
+  artistName: string,
+  config: Config
+): Promise<number | null> {
+  const { lastfmKey, lastfmUsername } = config;
+  const endpoint =
+    `https://ws.audioscrobbler.com/2.0/?method=artist.getinfo` +
+    `&artist=${encodeURIComponent(artistName)}` +
+    `&username=${lastfmUsername}&api_key=${lastfmKey}&format=json`;
+  try {
+    const response = await fetch(endpoint);
+    if (!response.ok) {
+      return null;
+    }
+    const data = (await response.json()) as LastFMArtistGetInfoResponse;
+    const userPlaycount = data.artist?.stats?.userplaycount;
+    if (userPlaycount === undefined) {
+      return null;
+    }
+    const parsed = Number.parseInt(userPlaycount, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function calculateVelocity(
+  currentTotal: number,
+  priorTotals: number[]
+): number | null {
+  if (priorTotals.length !== HISTORY_WEEKS) {
+    return null;
+  }
+  const trailingAverage =
+    priorTotals.reduce((sum, total) => sum + total, 0) / priorTotals.length;
+  if (trailingAverage === 0) {
+    return null;
+  }
+
+  return ((currentTotal - trailingAverage) / trailingAverage) * 100;
+}
+
+function calculateTopFiveCoverage(artists: ArtistPlay[]): number {
+  const total = artists.reduce((sum, artist) => sum + artist.playcount, 0);
+  if (total === 0) {
+    return 0;
+  }
+
+  const topFiveTotal = [...artists]
+    .sort((a, b) => b.playcount - a.playcount)
+    .slice(0, 5)
+    .reduce((sum, artist) => sum + artist.playcount, 0);
+  return (topFiveTotal / total) * 100;
+}
+
+export function generateProgressBar(fraction: number, size = BAR_SIZE): string {
+  if (!Number.isFinite(fraction)) {
+    const balanced = Math.floor(size / 2);
+    return "█".repeat(balanced) + "░".repeat(size - balanced);
+  }
+
+  const clamped = Math.min(Math.max(fraction, 0), 1);
+  const filled = Math.min(Math.max(Math.round(clamped * size), 0), size);
+  return "█".repeat(filled) + "░".repeat(size - filled);
+}
+
+function formatVelocity(velocity: number | null): string {
+  if (velocity === null) {
+    return "insufficient history";
+  }
+  return `${velocity >= 0 ? "+" : ""}${Math.round(velocity)}%`;
+}
+
+function describeDepth(score: number): string {
+  if (score >= 0.75) {
+    return "Deep Dive 🔬";
+  }
+  if (score >= 0.5) {
+    return "Focused Loop 🎯";
+  }
+  if (score >= 0.3) {
+    return "Balanced Mix 🎧";
+  }
+  return "Wide Discovery 🌍";
+}
+
+function describeVelocity(velocity: number | null): string {
+  if (velocity === null) {
+    return "insufficient history";
+  }
+  if (velocity >= 20) {
+    return "Surge week 🚀";
+  }
+  if (velocity >= 5) {
+    return "Binge week 🚀";
+  }
+  if (velocity > -5) {
+    return "Steady pace ➡️";
+  }
+  if (velocity > -20) {
+    return "Cool-off week 🧊";
+  }
+  return "Slow week 🐢";
+}
+
+function formatTrend(
+  label: string,
+  current: number,
+  previous: number | null,
+  formatter: (delta: number) => string
+): string {
+  if (previous === null) {
+    return `→ ${label} n/a`;
+  }
+
+  const delta = current - previous;
+  const arrow = delta > 0 ? "↗" : delta < 0 ? "↘" : "→";
+  return `${arrow} ${label} ${formatter(delta)}`;
+}
+
+function createAnalyticsMarkdown(args: {
+  runDate: string;
+  current: WeeklyMetrics;
+  currentDiscovery: DiscoveryMetrics;
+  velocity: number | null;
+  previousDepth: number | null;
+  previousDiscoveryRate: number | null;
+  previousVelocity: number | null;
+  topFiveCoverage: number;
+}) {
+  const {
+    runDate,
+    current,
+    currentDiscovery,
+    velocity,
+    previousDepth,
+    previousDiscoveryRate,
+    previousVelocity,
+    topFiveCoverage,
+  } = args;
+
+  const depthValue = current.depthScore.toFixed(2);
+  const depthBar = generateProgressBar(current.depthScore);
+  const discoveryPercent = Math.round(currentDiscovery.discoveryRate);
+  const discoveryBar = generateProgressBar(currentDiscovery.discoveryRate / 100);
+  const velocityBar = generateProgressBar(
+    velocity === null ? Number.NaN : Math.min(Math.abs(velocity) / 50, 1)
+  );
+
+  const velocityLabel = formatVelocity(velocity);
+  const depthTrend = formatTrend("Depth", current.depthScore, previousDepth, (delta) =>
+    `${delta >= 0 ? "+" : ""}${delta.toFixed(2)}`
+  );
+  const discoveryTrend = formatTrend(
+    "Discovery",
+    currentDiscovery.discoveryRate,
+    previousDiscoveryRate,
+    (delta) => `${delta >= 0 ? "+" : ""}${Math.round(delta)}%`
+  );
+  const velocityTrend =
+    velocity === null || previousVelocity === null
+      ? "→ Velocity insufficient history"
+      : formatTrend("Velocity", velocity, previousVelocity, (delta) =>
+          `${delta >= 0 ? "+" : ""}${Math.round(delta)}%`
+        );
+
+  return [
+    "📊 Weekly Listening Stats",
+    `DEPTH      ${depthValue}  ${depthBar}  ${describeDepth(current.depthScore)}`,
+    `DISCOVERY  ${discoveryPercent}%   ${discoveryBar}  ${currentDiscovery.newArtists} new artists *`,
+    `VELOCITY   ${velocityLabel}  ${velocityBar}  ${describeVelocity(velocity)}`,
+    "",
+    `vs last week: ${depthTrend}  ${discoveryTrend}  ${velocityTrend}`,
+    `Top 5 Coverage: ${Math.round(topFiveCoverage)}% of total plays`,
+    `Unique Artists: ${current.uniqueArtists}`,
+    `Total Scrobbles: ${current.totalScrobbles}`,
+    "",
+    "* = new this week",
+    `Updated at: ${new Date().toISOString()}`,
+  ].join("\n");
+}
+
+async function updateGist(
+  gist: GetResponseTypeFromEndpointMethod<typeof octokit.rest.gists.get>,
+  title: string,
+  content: string,
+  config: Config
+) {
+  try {
+    const filename = gist.data.files ? Object.keys(gist.data.files)[0] : "";
+
+    await octokit.rest.gists.update({
+      gist_id: config.gistId!,
+      files: {
+        [filename]: {
+          filename: title,
+          content,
+        },
+      },
+    });
+  } catch (error) {
+    console.error(`Unable to update gist:\n${error}`);
+    throw new Error(
+      `Failed to update gist: ${error instanceof Error ? error.message : error}`
+    );
+  }
+}
+
+if (!process.env.NODE_ENV?.includes("test")) {
+  (async () => {
+    await main();
+  })();
+}

--- a/index.test.ts
+++ b/index.test.ts
@@ -127,7 +127,7 @@ describe("Chart Generation Edge Cases", () => {
     
     const result = generateChart(NaN, 10);
     
-    expect(result).toBe("–––––|––––");
+    expect(result).toBe("█████░░░░░");
     expect(logMessages[0]).toBe("Invalid fraction value: NaN - using balanced chart");
     
     console.log = originalLog;
@@ -140,7 +140,7 @@ describe("Chart Generation Edge Cases", () => {
     
     const result = generateChart(Infinity, 10);
     
-    expect(result).toBe("–––––|––––");
+    expect(result).toBe("█████░░░░░");
     expect(logMessages[0]).toBe("Invalid fraction value: Infinity - using balanced chart");
     
     console.log = originalLog;
@@ -153,7 +153,7 @@ describe("Chart Generation Edge Cases", () => {
     
     const result = generateChart(-0.5, 10);
     
-    expect(result).toBe("–––––|––––");
+    expect(result).toBe("█████░░░░░");
     expect(logMessages[0]).toBe("Invalid fraction value: -0.5 - using balanced chart");
     
     console.log = originalLog;
@@ -161,17 +161,17 @@ describe("Chart Generation Edge Cases", () => {
 
   test("should handle normal input correctly", () => {
     const result = generateChart(0.3, 10);
-    expect(result).toBe("–––|––––––");
+    expect(result).toBe("███░░░░░░░");
   });
 
   test("should handle 0% fraction correctly", () => {
     const result = generateChart(0, 10);
-    expect(result).toBe("|–––––––––");
+    expect(result).toBe("░░░░░░░░░░");
   });
 
   test("should handle 100% fraction correctly", () => {
     const result = generateChart(1, 10);
-    expect(result).toBe("–––––––––|");
+    expect(result).toBe("██████████");
   });
 });
 

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,7 @@ import stringWidth from "string-width";
 const MAX_NUM_ARTISTS = 5;
 
 const config = {
-  gistId: process.env.GIST_ID,
+  gistId: process.env.ARTISTS_GIST_ID ?? process.env.GIST_ID,
   githubToken: process.env.GH_TOKEN,
   lastfmKey: process.env.LASTFM_KEY,
   lastfmUsername: process.env.LASTFM_USERNAME,
@@ -83,7 +83,7 @@ async function getGist<GistResponseDataType>(id: string) {
 async function getTopArtists(config: Config) {
   const { lastfmKey, lastfmUsername } = config;
   const API_BASE =
-    "http://ws.audioscrobbler.com/2.0/?method=user.gettopartists&format=json&period=7day&";
+    "https://ws.audioscrobbler.com/2.0/?method=user.gettopartists&format=json&period=7day&";
   const API_ENDPOINT = `${API_BASE}user=${lastfmUsername}&api_key=${lastfmKey}&limit=${MAX_NUM_ARTISTS}`;
   const response = await fetch(API_ENDPOINT);
   if (!response.ok) {
@@ -121,7 +121,7 @@ export async function createTopArtistList(
   }
 
   const lines = await Promise.all(
-    artists.map(async ({ name, playcount }, index) => {
+    artists.slice(0, numberOfArtists).map(async ({ name, playcount }, index) => {
       // Find out if artist is new this week
       const isNewThisWeek = await isArtistNewThisWeek(
         name,
@@ -140,7 +140,10 @@ export async function createTopArtistList(
     })
   );
 
-  return lines.join("\n") + `\n\n* = new this week`;
+  return (
+    lines.join("\n") +
+    `\n\n* = new this week`
+  );
 }
 
 export function adjustAndPad(str: string, maxWidth: number) {
@@ -174,13 +177,11 @@ export function generateChart(fraction: number, size: number) {
     console.log(`Invalid fraction value: ${fraction} - using balanced chart`);
     // Return a balanced chart as fallback
     const middle = Math.floor(size / 2);
-    return "–".repeat(middle) + "|" + "–".repeat(size - middle - 1);
+    return "█".repeat(middle) + "░".repeat(size - middle);
   }
   
-  const position = Math.floor(fraction * size);
-  // Ensure position is within bounds (0 to size-1)
-  const clampedPosition = Math.min(Math.max(position, 0), size - 1);
-  return "–".repeat(clampedPosition) + "|" + "–".repeat(size - clampedPosition - 1);
+  const filled = Math.min(Math.max(Math.round(fraction * size), 0), size);
+  return "█".repeat(filled) + "░".repeat(size - filled);
 }
 
 async function isArtistNewThisWeek(
@@ -189,7 +190,7 @@ async function isArtistNewThisWeek(
   config: Config
 ) {
   const { lastfmKey, lastfmUsername } = config;
-  const API_ENDPOINT = `http://ws.audioscrobbler.com/2.0/?method=artist.getinfo&artist=${name}&username=${lastfmUsername}&api_key=${lastfmKey}&format=json`;
+  const API_ENDPOINT = `https://ws.audioscrobbler.com/2.0/?method=artist.getinfo&artist=${name}&username=${lastfmUsername}&api_key=${lastfmKey}&format=json`;
   try {
     const response = await fetch(API_ENDPOINT);
     if (!response.ok) {
@@ -225,9 +226,7 @@ async function updateGist(
       gist_id: config.gistId!,
       files: {
         [filename]: {
-          filename: `🎧 This week's soundtrack ${
-            new Date().toISOString().split("T")[0]
-          }`,
+          filename: title,
           content,
         },
       },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "node --env-file=.env dist/index.js",
     "build": "tsup",
     "dev": "tsup --watch && npm run start",
+    "dry-run-all": "bun run build && NODE_ENV=development bun --env-file=.env dist/index.js && NODE_ENV=development bun --env-file=.env dist/analytics.js",
     "prepare": "npm run build",
     "test": "echo 'This project uses Bun for testing. Running `bun test`' && bun test"
   },

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   clean: true,
   minify: false,
   bundle: true,
-  entry: ["index.ts"],
+  entry: ["index.ts", "analytics.ts"],
   format: ["esm"],
   sourcemap: true,
   target: "esnext",

--- a/types.ts
+++ b/types.ts
@@ -70,3 +70,44 @@ export type LastFMArtistGetInfoResponse = Readonly<{
     };
   };
 }>;
+
+export type LastFMUserGetWeeklyChartListResponse = Readonly<{
+  weeklychartlist: {
+    chart: Array<{
+      from: string;
+      to: string;
+    }>;
+    "@attr": {
+      user: string;
+    };
+  };
+}>;
+
+export type LastFMUserGetWeeklyArtistChartResponse = Readonly<{
+  weeklyartistchart: {
+    artist:
+      | Array<{
+          mbid: string;
+          playcount: string;
+          url: string;
+          name: string;
+          "@attr"?: {
+            rank: string;
+          };
+        }>
+      | {
+          mbid: string;
+          playcount: string;
+          url: string;
+          name: string;
+          "@attr"?: {
+            rank: string;
+          };
+        };
+    "@attr": {
+      user: string;
+      from: string;
+      to: string;
+    };
+  };
+}>;


### PR DESCRIPTION
Adds a second updater that publishes a weekly analytics gist alongside the existing artist gist.

## Changes

- Added analytics.ts to generate:
  - Depth (Gini)
  - Discovery (`userplaycount == weekly_playcount`)
  - Velocity vs trailing 4-week average (insufficient history fallback)
  - Top 5 coverage, unique artists, total scrobbles, WoW trend line
- Updated workflow to run **artist** and **analytics** gist updates separately with partial-failure behaviour (job fails only if both fail)
- Make all chart bars `█/░` 
- Added Last.fm API response types
- Added analytics tests and updated chart expectations
- Added `dry-run-all` script for local non-destructive runs

### Secrets
- New: `ARTISTS_GIST_ID`, `ANALYTICS_GIST_ID`
- Existing: `GH_TOKEN, `LASTFM_KEY`, `LASTFM_USERNAME`