### PR TITLE
Refactor analytics output to plain table and add Artists trend metric

### DIFF
--- a/analytics.test.ts
+++ b/analytics.test.ts
@@ -70,7 +70,7 @@ describe("createAnalyticsMarkdown", () => {
       })
     ).toBe(`METRIC     THIS WEEK                CHANGE
 Depth      0.45  balanced mix       ↓ -0.16
-Discovery  Medium (15 new artists)  ↑ +16%
+Artists    15 new / 46 total        ↑ +16%
 Velocity   ↓ 49%  slow week         ↓ -127%
 
 SUMMARY
@@ -78,6 +78,7 @@ Top 5 coverage   47% of total plays
 Unique artists   46
 Total scrobbles  96
 
+Artists change = discovery rate vs last week
 Velocity = change vs trailing 4-week average`);
   });
 

--- a/analytics.ts
+++ b/analytics.ts
@@ -417,16 +417,6 @@ function describeDepth(score: number): string {
   return "wide discovery";
 }
 
-function describeDiscoveryLevel(rate: number): string {
-  if (rate >= 40) {
-    return "High";
-  }
-  if (rate >= 20) {
-    return "Medium";
-  }
-  return "Low";
-}
-
 function describeVelocity(velocity: number | null): string {
   if (velocity === null) {
     return "insufficient history";
@@ -489,9 +479,7 @@ export function createAnalyticsMarkdown(args: {
   const depthValue = `${current.depthScore.toFixed(2)}  ${describeDepth(
     current.depthScore
   )}`;
-  const discoveryValue = `${describeDiscoveryLevel(
-    currentDiscovery.discoveryRate
-  )} (${currentDiscovery.newArtists} new artists)`;
+  const artistsValue = `${currentDiscovery.newArtists} new / ${current.uniqueArtists} total`;
   const velocityValue =
     velocity === null
       ? "insufficient history"
@@ -515,7 +503,7 @@ export function createAnalyticsMarkdown(args: {
   return [
     "METRIC     THIS WEEK                CHANGE",
     formatMetricRow("Depth", depthValue, depthTrend),
-    formatMetricRow("Discovery", discoveryValue, discoveryTrend),
+    formatMetricRow("Artists", artistsValue, discoveryTrend),
     formatMetricRow("Velocity", velocityValue, velocityTrend),
     "",
     "SUMMARY",
@@ -523,6 +511,7 @@ export function createAnalyticsMarkdown(args: {
     formatSummaryRow("Unique artists", current.uniqueArtists),
     formatSummaryRow("Total scrobbles", current.totalScrobbles),
     "",
+    "Artists change = discovery rate vs last week",
     "Velocity = change vs trailing 4-week average",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary
- rename the Discovery metric to **Artists** and show `new / total` artist counts
- replace bar/emoji-based analytics markdown with a plain text table including a dedicated **CHANGE** column
- standardize trend formatting with directional arrows and `n/a` when prior-week history is missing
- add summary rows plus explanatory footnotes for Artists and Velocity change semantics
- export `createAnalyticsMarkdown` and add focused unit tests for table rendering and missing-history behavior

## Testing
- Added unit tests in `analytics.test.ts` for `createAnalyticsMarkdown`:
- verifies table-style output (no bars/emoji), Artists `new / total` display, and change column formatting
- verifies Velocity row renders `insufficient history` with `n/a` change when comparison data is unavailable
- Not run: full test suite execution status not provided